### PR TITLE
stop propagation on click event

### DIFF
--- a/form-request-submit-polyfill.js
+++ b/form-request-submit-polyfill.js
@@ -11,6 +11,7 @@
       submitter.hidden = true
       this.appendChild(submitter)
       submitter.click()
+      submitter.onclick = (e) => e.stopPropagation()
       this.removeChild(submitter)
     }
   }


### PR DESCRIPTION
we ran in an issue where we use requestSubmit on a form that we're showing in a modal
Using a click event listener and checking if the click was outside of the modal (using `modal.contains(clickedTarget)`) to close the modal. (using [stimulus useClickOutside](https://github.com/stimulus-use/stimulus-use/blob/main/docs/use-click-outside.md))

I found that adding `stopPropagation()` to a submitter click event fixed the issue for us, but not sure whether this would potentially break things elsewhere